### PR TITLE
Add ICS to Google Calendar in one click

### DIFF
--- a/client/src/app/translations.js
+++ b/client/src/app/translations.js
@@ -26,7 +26,7 @@ export default {
         ApplySelection: 'Appliquer',
         IcsCalendar: 'Calendrier ICS',
         Instructions: 'Instructions (Google Agenda)',
-        DetailedInstructions: 'Cliquez sur le "+" au dessus de vos agendas, et choisissez "À partir de l\'URL". Copiez alors l\'URL ci-dessus.',
+        DetailedInstructions: 'Cliquez sur le "+" au dessus de vos agendas, et choisissez "À partir de l\'URL". Copiez alors l\'URL ci-dessus. Vous pouvez aussi cliquer directement sur le bouton ci-dessous.',
         ExportCalendar: 'Exporter le calendrier',
         ClickToCopy: 'Cliquer pour copier',
         SwitchLanguage: 'Switch to English',

--- a/client/src/components/other/IcsPage.jsx
+++ b/client/src/components/other/IcsPage.jsx
@@ -81,7 +81,7 @@ export default class extends React.Component {
                         <Typography variant="subtitle1" gutterBottom>
                             <T.DetailedInstructions/>
                         </Typography>
-                        <Button size="small" href="https://calendar.google.com/calendar/r">Google Agenda <OpenInNew fontSize="small"/></Button>
+                        <Button size="small" href={"https://calendar.google.com/calendar/r?cid=" + this.link}>Google Agenda <OpenInNew fontSize="small"/></Button>
                     </Paper>
                 </PageContent>
             </Page>


### PR DESCRIPTION
The Google Calendar link auto add the ICS url to Google Calendar